### PR TITLE
Azure dev ops2020

### DIFF
--- a/NuKeeper.Abstractions/CollaborationModels/User.cs
+++ b/NuKeeper.Abstractions/CollaborationModels/User.cs
@@ -2,7 +2,7 @@ namespace NuKeeper.Abstractions.CollaborationModels
 {
     public class User
     {
-        public static readonly User Default = new User("user@email.com", "", "");
+        public static readonly User Default = new User("user@email.com", "user", "");
 
         public User(string login, string name, string email)
         {

--- a/NuKeeper.AzureDevOps/AzureDevOpsRestClient.cs
+++ b/NuKeeper.AzureDevOps/AzureDevOpsRestClient.cs
@@ -24,11 +24,6 @@ namespace NuKeeper.AzureDevOps
         {
             _logger = logger;
 
-            //massage the apiBaseAddress so the trailing slash gets removed
-            //fixes issue with tfs/azure dev ops server on prem uri not using /tfs
-            var u = apiBaseAddress?.AbsoluteUri.TrimEnd(new[] { '/' });
-            var uri = new Uri(u);
-
             _client = clientFactory.CreateClient();
             _client.BaseAddress = apiBaseAddress;
             _client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));

--- a/NuKeeper.AzureDevOps/AzureDevOpsRestClient.cs
+++ b/NuKeeper.AzureDevOps/AzureDevOpsRestClient.cs
@@ -24,6 +24,11 @@ namespace NuKeeper.AzureDevOps
         {
             _logger = logger;
 
+            //massage the apiBaseAddress so the trailing slash gets removed
+            //fixes issue with tfs/azure dev ops server on prem uri not using /tfs
+            var u = apiBaseAddress?.AbsoluteUri.TrimEnd(new[] { '/' });
+            var uri = new Uri(u);
+
             _client = clientFactory.CreateClient();
             _client.BaseAddress = apiBaseAddress;
             _client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
@@ -57,7 +62,9 @@ namespace NuKeeper.AzureDevOps
             var fullUrl = BuildAzureDevOpsUri(url, previewApi);
             _logger.Detailed($"{caller}: Requesting {fullUrl}");
 
-            var response = await _client.GetAsync(fullUrl);
+            var tt = fullUrl.OriginalString.TrimStart(new[] { '/' });
+
+            var response = await _client.GetAsync(tt);
             return await HandleResponse<T>(response, caller);
         }
 

--- a/Nukeeper.AzureDevOps.Tests/AzureDevOpsRepositoryDiscoveryTests.cs
+++ b/Nukeeper.AzureDevOps.Tests/AzureDevOpsRepositoryDiscoveryTests.cs
@@ -21,7 +21,11 @@ namespace Nukeeper.AzureDevOps.Tests
         {
             var settings = new SourceControlServerSettings
             {
-                Repository = new RepositorySettings { RepositoryUri = new Uri("https://repo/") },
+                Repository = new RepositorySettings
+                {
+                    RepositoryUri = new Uri("https://repo/tfs"),
+                    ApiUri = new Uri("https://repo/tfs/_apis")
+                },
                 Scope = ServerScope.Repository
             };
 

--- a/Nukeeper.AzureDevOps.Tests/AzureDevopsPlatformTests.cs
+++ b/Nukeeper.AzureDevOps.Tests/AzureDevopsPlatformTests.cs
@@ -11,13 +11,23 @@ namespace Nukeeper.AzureDevOps.Tests
     public class AzureDevOpsPlatformTests
     {
         [Test]
-        public void Initialise()
+        public void InitialiseAgain()
         {
             var httpClientFactory = Substitute.For<IHttpClientFactory>();
             httpClientFactory.CreateClient().Returns(new HttpClient());
 
             var platform = new AzureDevOpsPlatform(Substitute.For<INuKeeperLogger>(), httpClientFactory);
             platform.Initialise(new AuthSettings(new Uri("https://uri.com"), "token"));
+        }
+
+        [Test]
+        public void Initialise()
+        {
+            var httpClientFactory = Substitute.For<IHttpClientFactory>();
+            httpClientFactory.CreateClient().Returns(new HttpClient());
+
+            var platform = new AzureDevOpsPlatform(Substitute.For<INuKeeperLogger>(), httpClientFactory);
+            platform.Initialise(new AuthSettings(new Uri("https://uri.com/tfs"), "token"));
         }
     }
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug Fixes. Specific to Azure DevOps server 2020 behavior. Have not tested others.

### :arrow_heading_down: What is the current behavior?
The current API URI is not correct when using TFS/ADOS

### :new: What is the new behavior (if this is a feature change)?
Updated the URI path for how the api path is decided. Removed first slash to the URI strings are concatenated properly when using TFS or Azure DevOps Server.
Clone required a custom Authorization header to work with TFS/ Azure DevOps Server 2020
Push required the removal of the explicit credentials to work with TFS/ Azure DevOps Server 2020

This is specific to a use case where the application will only be used on Azure DevOps Server 2020


