### PR TITLE
Azure dev ops2020

### DIFF
--- a/NuKeeper.AzureDevOps/AzureDevOpsRepositoryDiscovery.cs
+++ b/NuKeeper.AzureDevOps/AzureDevOpsRepositoryDiscovery.cs
@@ -40,7 +40,7 @@ namespace NuKeeper.AzureDevOps
 
                 case ServerScope.Repository:
                     
-                    settings.Repository.RepositoryUri = PasswordReplacedRepositoryUri(settings.Repository.RepositoryUri);
+                    //settings.Repository.RepositoryUri = PasswordReplacedRepositoryUri(settings.Repository.RepositoryUri);
                     return new List<RepositorySettings> { settings.Repository }.AsEnumerable();
 
                 default:
@@ -95,10 +95,11 @@ namespace NuKeeper.AzureDevOps
                 repo.UserPermissions.Pull;
         }
 
-        private RepositorySettings CreateRepositorySettings(string org, Uri repositoryUri, string project, string repoName, RemoteInfo remoteInfo = null) => new RepositorySettings
+        private static RepositorySettings CreateRepositorySettings(string org, Uri repositoryUri, string project, string repoName, RemoteInfo remoteInfo = null) => new RepositorySettings
         {
             ApiUri = string.IsNullOrWhiteSpace(org) ? new Uri($"https://dev.azure.com/") : new Uri($"https://dev.azure.com/{org}/"),
-            RepositoryUri = PasswordReplacedRepositoryUri(repositoryUri),
+            //RepositoryUri = PasswordReplacedRepositoryUri(repositoryUri),
+            RepositoryUri = repositoryUri,
             RepositoryName = repoName,
             RepositoryOwner = project,
             RemoteInfo = remoteInfo

--- a/NuKeeper.AzureDevOps/AzureDevOpsRestClient.cs
+++ b/NuKeeper.AzureDevOps/AzureDevOpsRestClient.cs
@@ -28,7 +28,7 @@ namespace NuKeeper.AzureDevOps
             _client.BaseAddress = apiBaseAddress;
             _client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
             _client.DefaultRequestHeaders.Authorization =
-                new AuthenticationHeaderValue("Basic", Convert.ToBase64String(Encoding.ASCII.GetBytes($"{string.Empty}:{personalAccessToken}")));
+                new AuthenticationHeaderValue("Basic", Convert.ToBase64String(ASCIIEncoding.ASCII.GetBytes($"{string.Empty}:{personalAccessToken}")));
         }
 
         private async Task<T> PostResource<T>(string url, HttpContent content, bool previewApi = false, [CallerMemberName] string caller = null)

--- a/NuKeeper.AzureDevOps/TfsSettingsReader.cs
+++ b/NuKeeper.AzureDevOps/TfsSettingsReader.cs
@@ -119,7 +119,7 @@ namespace NuKeeper.AzureDevOps
             {
                 ApiUri = new Uri($"{repositoryUri.Scheme}://{repositoryUri.Host}:{repositoryUri.Port}/{apiPathParts.JoinWithSeparator("/")}"),
                 RepositoryUri = new Uri(
-                    $"{repositoryUri.Scheme}://user:--PasswordToReplace--@{repositoryUri.Host}:{repositoryUri.Port}/{apiPathParts.JoinWithSeparator("/")}/{project}/_git/{repoName}/"),
+                    $"{repositoryUri.Scheme}://{repositoryUri.Host}:{repositoryUri.Port}/{apiPathParts.JoinWithSeparator("/")}/{project}/_git/{repoName}/"),
                 RepositoryName = repoName,
                 RepositoryOwner = project,
                 RemoteInfo = remoteInfo

--- a/NuKeeper.Git/GitCmdDriver.cs
+++ b/NuKeeper.Git/GitCmdDriver.cs
@@ -90,7 +90,7 @@ namespace NuKeeper.Git
                 
                 
                 var branchparam = branchName == null ? "" : $" -b {branchName}";
-                var args = $"-c http.sslVerify=false {GeneratePatString(_gitCredentials.Password)} clone{branchparam} \"{pullEndpoint.AbsoluteUri}\" .";
+                var args = $"{GeneratePatString(_gitCredentials.Password)} clone{branchparam} \"{pullEndpoint.AbsoluteUri}\" .";
 
                 _logger.Normal(
                     $"Git {args}, branch {branchName ?? "default"}, to {WorkingFolder.FullPath}");
@@ -118,7 +118,7 @@ namespace NuKeeper.Git
         public async Task Push(string remoteName, string branchName)
         {
             _logger.Detailed($"Git push to {remoteName}/{branchName}");
-            await StartGitProcess($"-c http.sslVerify=false {GeneratePatString(_gitCredentials.Password)} push \"{remoteName}\" {branchName}", true);
+            await StartGitProcess($"{GeneratePatString(_gitCredentials.Password)} push \"{remoteName}\" {branchName}", true);
         }
 
         private  async Task<string> StartGitProcess(string arguments, bool ensureSuccess)

--- a/NuKeeper.Git/GitCmdDriver.cs
+++ b/NuKeeper.Git/GitCmdDriver.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using NuKeeper.Abstractions.Git;
 using NuKeeper.Abstractions.Inspections.Files;
@@ -39,7 +40,20 @@ namespace NuKeeper.Git
 
         public async Task AddRemote(string name, Uri endpoint)
         {
-            await StartGitProcess($"remote add {name} {CreateCredentialsUri(endpoint, _gitCredentials)}", true);
+            if (endpoint != null)
+            {
+                var uri = CreateCredentialsUri(endpoint, _gitCredentials);
+
+                await StartGitProcess($"remote add {name} {uri.AbsoluteUri}", true);
+            }
+        }
+
+        private static string GeneratePatString(string token)
+        {
+            var encoded = Convert.ToBase64String(Encoding.ASCII.GetBytes($"{string.Empty}:{token}"));
+            var header = $"-c http.extraHeader=\"Authorization: Basic {encoded}\"";
+
+            return header;
         }
 
         public async Task Checkout(string branchName)
@@ -71,10 +85,20 @@ namespace NuKeeper.Git
 
         public async Task Clone(Uri pullEndpoint, string branchName)
         {
-            _logger.Normal($"Git clone {pullEndpoint}, branch {branchName ?? "default"}, to {WorkingFolder.FullPath}");
-            var branchparam = branchName == null ? "" : $" -b {branchName}";
-            await StartGitProcess($"clone{branchparam} {CreateCredentialsUri(pullEndpoint, _gitCredentials)} .", true); // Clone into current folder
-            _logger.Detailed("Git clone complete");
+            if (pullEndpoint != null)
+            {
+                
+                
+                var branchparam = branchName == null ? "" : $" -b {branchName}";
+                var args = $"-c http.sslVerify=false {GeneratePatString(_gitCredentials.Password)} clone{branchparam} \"{pullEndpoint.AbsoluteUri}\" .";
+
+                _logger.Normal(
+                    $"Git {args}, branch {branchName ?? "default"}, to {WorkingFolder.FullPath}");
+
+                await StartGitProcess(args,
+                    true); // Clone into current folder
+                _logger.Detailed("Git clone complete");
+            }
         }
 
         public async Task Commit(string message)
@@ -94,7 +118,7 @@ namespace NuKeeper.Git
         public async Task Push(string remoteName, string branchName)
         {
             _logger.Detailed($"Git push to {remoteName}/{branchName}");
-            await StartGitProcess($"push {remoteName} {branchName}", true);
+            await StartGitProcess($"-c http.sslVerify=false {GeneratePatString(_gitCredentials.Password)} push \"{remoteName}\" {branchName}", true);
         }
 
         private  async Task<string> StartGitProcess(string arguments, bool ensureSuccess)
@@ -111,7 +135,11 @@ namespace NuKeeper.Git
                 return pullEndpoint;
             }
 
-            return new UriBuilder(pullEndpoint) { UserName = Uri.EscapeDataString(gitCredentials.Username), Password = gitCredentials.Password }.Uri;
+            _logger.Detailed(gitCredentials.Username);
+
+            return pullEndpoint;
+            //return new UriBuilder(pullEndpoint)
+            //    { UserName = Uri.EscapeDataString(gitCredentials.Username), Password = gitCredentials.Password }.Uri;
         }
 
         public async Task<IReadOnlyCollection<string>> GetNewCommitMessages(string baseBranchName, string headBranchName)


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
This change updates the behavior of the rest client and git client (cmd line) so that it will use an additional auth header with the PAT token encoded as base 64 for authentication rather than using the username/pw in the url.

### :arrow_heading_down: What is the current behavior?
The current behavior uses username password in the url and does not reliably work with azure dev ops server a lot of the time.
